### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#No Longer Maintained.
+# No Longer Maintained.
 
 Do you need a professional backend for your iOS app? Add one with **DeploydKit** for [Deployd](http://www.deployd.com) in minutes!
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
